### PR TITLE
fix: decorator wrapper and tests

### DIFF
--- a/kstreams/streams.py
+++ b/kstreams/streams.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import logging
 import uuid
+from functools import update_wrapper
 from typing import (
     Any,
     AsyncGenerator,
@@ -156,12 +157,14 @@ def stream(
     **kwargs,
 ) -> Callable[[StreamFunc], Stream]:
     def decorator(func: StreamFunc) -> Stream:
-        return Stream(
+        s = Stream(
             topics=topics,
             func=func,
             name=name,
             deserializer=deserializer,
             config=kwargs,
         )
+        update_wrapper(s, func)
+        return s
 
     return decorator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections import namedtuple
 from dataclasses import field
 from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple
@@ -147,11 +146,6 @@ def schema_server_url(httpserver: HTTPServer):
 @pytest.fixture
 def avro_schema_v1():
     return AVRO_SCHEMA_V1
-
-
-@pytest.fixture()
-def event_loop():
-    return asyncio.get_event_loop()
 
 
 @pytest.fixture()


### PR DESCRIPTION
This PR doesn't introduce much, just removes some unused code, adds tests for the stream decorator and checks it's properly wrapping.