### PR TITLE
fix: use partition 1 as default partition when producing with test cl…

### DIFF
--- a/kstreams/test_utils/test_clients.py
+++ b/kstreams/test_utils/test_clients.py
@@ -51,7 +51,7 @@ class TestProducer(Base, Producer):
         async def fut():
             return RecordMetadata(
                 topic=topic_name,
-                partition=1,
+                partition=partition,
                 timestamp=timestamp_ms,
                 offset=total_messages,
             )

--- a/kstreams/test_utils/test_utils.py
+++ b/kstreams/test_utils/test_utils.py
@@ -70,7 +70,7 @@ class TestStreamClient:
         topic: str,
         value: Any = None,
         key: Optional[Any] = None,
-        partition: Optional[int] = None,
+        partition: int = 1,
         timestamp_ms: Optional[int] = None,
         headers: Optional[Headers] = None,
         serializer: Optional[Serializer] = None,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,6 +37,7 @@ async def test_send_event_with_test_client(stream_engine: StreamEngine):
         )
         current_offset = metadata.offset
         assert metadata.topic == topic
+        assert metadata.partition == 1
 
         # send another event and check that the offset was incremented
         metadata = await client.send(
@@ -109,7 +110,10 @@ async def test_consumer_commit(stream_engine: StreamEngine):
     client = TestStreamClient(stream_engine)
     async with client:
         for _ in range(0, total_events):
-            await client.send(topic_name, partition=partition, value=value, key=key)
+            record_metadata = await client.send(
+                topic_name, partition=partition, value=value, key=key
+            )
+            assert record_metadata.partition == partition
 
     # check that everything was commited
     stream = stream_engine.get_stream(name)


### PR DESCRIPTION
…ient. Producer test client record metadata fixed. Closes #64