### PR TITLE
fix(TestStreamClient): remove unused/unclosed mock producer

### DIFF
--- a/kstreams/test_utils/test_utils.py
+++ b/kstreams/test_utils/test_utils.py
@@ -29,12 +29,7 @@ class TestStreamClient:
         for stream in streams:
             stream.consumer_class = TestConsumer
 
-    def mock_producer(self) -> None:
-        producer = TestProducer()
-        self.stream_engine._producer = producer
-
     def setup_mocks(self) -> None:
-        self.mock_producer()
         self.mock_streams()
 
     async def start(self) -> None:


### PR DESCRIPTION
TestStreamClient sets the producer_class to start the mock producer on startup. If a mock producer is created beforehand it is immediately overwritten and leaves an unclosed producer, raising error logs from aiokafka.

This is not noticeable in the projects' tests as it happens on `del` of the producer object. In my project the garbage collection will show up at random times and raise this error log:
```
ERROR    asyncio              :: Unclosed AIOKafkaProducer
producer: <kstreams.test_utils.test_clients.TestProducer object at 0x1073ee620>
```