### PR TITLE
perf(test_utils): replace sleep with async queue join when stopping test stream

### DIFF
--- a/kstreams/test_utils/test_utils.py
+++ b/kstreams/test_utils/test_utils.py
@@ -1,4 +1,3 @@
-import asyncio
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Type
 
@@ -14,6 +13,8 @@ from .topics import Topic, TopicManager
 
 
 class TestStreamClient:
+    __test__ = False
+
     def __init__(self, stream_engine: StreamEngine) -> None:
         self.stream_engine = stream_engine
 
@@ -40,8 +41,7 @@ class TestStreamClient:
     async def stop(self) -> None:
         # If there are streams, we must wait until all the messages are consumed
         if self.stream_engine._streams:
-            while not TopicManager.all_messages_consumed():
-                await asyncio.sleep(1)
+            await TopicManager.join()
 
         await self.stream_engine.stop()
 

--- a/kstreams/test_utils/topics.py
+++ b/kstreams/test_utils/topics.py
@@ -29,6 +29,12 @@ class Topic:
     async def get(self) -> ConsumerRecord:
         return await self.queue.get()
 
+    def task_done(self) -> None:
+        self.queue.task_done()
+
+    async def join(self) -> None:
+        await self.queue.join()
+
     def is_empty(self) -> bool:
         return self.queue.empty()
 
@@ -105,6 +111,13 @@ class TopicManager:
             if not topic.consumed:
                 return False
         return True
+
+    @classmethod
+    async def join(cls) -> None:
+        """
+        Wait for all topic messages to be processed
+        """
+        await asyncio.gather(*[topic.join() for topic in cls.topics.values()])
 
     @classmethod
     def clean(cls) -> None:

--- a/tests/test_stream_engine.py
+++ b/tests/test_stream_engine.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import mock
 
 import pytest
@@ -94,6 +95,8 @@ async def test_start_stop_streaming(stream_engine: StreamEngine):
             await stream_engine.start()
             Consumer.start.assert_awaited()
             stream_engine._producer.start.assert_awaited()
+
+            await asyncio.sleep(0)  # Allow stream coroutine to run once
 
             await stream_engine.stop()
             stream_engine._producer.stop.assert_awaited()


### PR DESCRIPTION
TestStreamClient uses async queues in the background, which can be awaited for all processing to be done. This speeds up tests starting and stopping the TestStreamClient by removing the 1s sleep.

An assumption is made to call `task_done` in the TestConsumer.getone, as there is no callback towards the consumer after processing a record. I believe the existing test cases should still be sufficient, please let me know if you see some edge cases where this would not work or needs extra testing.