### PR TITLE
fix: Prometheus scrape metrics task fixed in order to have a proper s…

### DIFF
--- a/kstreams/engine.py
+++ b/kstreams/engine.py
@@ -139,9 +139,9 @@ class StreamEngine:
         self.monitor.start()
 
     async def stop(self) -> None:
-        await self.stop_streams()
-        await self.stop_producer()
         await self.monitor.stop()
+        await self.stop_producer()
+        await self.stop_streams()
 
     async def stop_producer(self):
         logger.info("Waiting Producer to STOP....")


### PR DESCRIPTION
…hutdown

The monitor shutdown will wait until the scraping Task is done rather than canceling it. Parameter metrics_scrape_time added.