### PR TITLE
fix(Kafka backend): use enum values when represent kafka backend as d…

### DIFF
--- a/kstreams/backends/kafka.py
+++ b/kstreams/backends/kafka.py
@@ -63,6 +63,7 @@ class Kafka(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+        use_enum_values = True
 
     @root_validator
     def protocols_validation(cls, values):

--- a/tests/test_backend_kafka.py
+++ b/tests/test_backend_kafka.py
@@ -99,3 +99,21 @@ def test_sasl_ssl_fail_missing_ssl_context():
             sasl_plain_password=password,
         )
     assert "ssl_context" in str(e.value.args[0])
+
+
+def test_backend_to_dict():
+    kafka_backend = Kafka(
+        security_protocol=SecurityProtocol.SASL_PLAINTEXT,
+        sasl_plain_username="username",
+        sasl_plain_password="pwd",
+    )
+    assert kafka_backend.security_protocol == SecurityProtocol.SASL_PLAINTEXT
+    assert kafka_backend.dict() == {
+        "bootstrap_servers": ["localhost:9092"],
+        "security_protocol": "SASL_PLAINTEXT",
+        "ssl_context": None,
+        "sasl_mechanism": "PLAIN",
+        "sasl_plain_username": "username",
+        "sasl_plain_password": "pwd",
+        "sasl_oauth_token_provider": None,
+    }


### PR DESCRIPTION
…ict. Close #130

Currently when a Kafka backend is created, enums are not properly represented causing errors when instantiating  `producers` and `consumers`. We rely on `backend.dict()` to propagate the `kafka  configuration`: [producer instantiation](https://github.com/kpn/kstreams/blob/master/kstreams/engine.py#L154) and [consumer instantiation](https://github.com/kpn/kstreams/blob/master/kstreams/streams.py#L121)

Example:

```python
from kstreams.backends.kafka import  Kafka, SecurityProtocol

kafka_backend = Kafka(
    security_protocol=SecurityProtocol.SASL_PLAINTEXT,
    sasl_plain_username="username",
    sasl_plain_password="pwd",
)

kafka_backend.dict()

{
    'bootstrap_servers': ['localhost:9092'],
    'security_protocol': <SecurityProtocol.SASL_PLAINTEXT: 'SASL_PLAINTEXT'>,  # WRONG 
    'ssl_context': None,
    'sasl_mechanism': <SaslMechanism.PLAIN: 'PLAIN'>,    # WRONG 
    'sasl_plain_username': 'username',
    'sasl_plain_password': 'pwd',
    'sasl_oauth_token_provider': None
}

print(Kafka(sasl_mechanism='PLAIN').sasl_mechanism) 
# <SaslMechanism.PLAIN: 'PLAIN'>
```

This patch will fix the `dict` representation:

```python
{
   'bootstrap_servers': ['localhost:9092'],
    'security_protocol': 'SASL_PLAINTEXT',  # Expected by aiokafka
    'ssl_context': None,
    'sasl_mechanism': 'PLAIN',  # Expected by aiokafka
    'sasl_plain_username': 'username',
    'sasl_plain_password': 'pwd',
    'sasl_oauth_token_provider': None
}


assert Kafka(sasl_mechanism='PLAIN').sasl_mechanism) == 'PLAIN'
```