### PR TITLE
fix(pyproject.toml): Lock pydantic on > 2.0 because it is not compatible with 1.x since v0.15.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1128,6 +1128,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1474,4 +1475,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "4a49d3aab25a77e8bab8888605d9b3a5894e88330a98ec6a3b794dd9a6546390"
+content-hash = "22094be5d548ba5d5816d373ebe75a818bb72f67c9803917a6b120c379014095"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ aiokafka = "<1.0"
 prometheus-client = "<1.0"
 future = "^0.18.2"
 PyYAML = ">=5.4,<7.0.0"
-pydantic = "<3.0.0"
+pydantic = ">=2.0.0,<3.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1"


### PR DESCRIPTION
Adds constraint missed on #156 