### PR TITLE
feat(TestStreamClient): support custom classes for test consumers and producers

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,8 +29,8 @@ async def test_engine_clients(stream_engine: StreamEngine):
         assert stream_engine.producer_class is TestProducer
 
     # after leaving the context, everything should go to normal
-    assert client.stream_engine.consumer_class is client.consumer_class
-    assert client.stream_engine.producer_class is client.producer_class
+    assert client.stream_engine.consumer_class is client.engine_consumer_class
+    assert client.stream_engine.producer_class is client.engine_producer_class
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Useful for more control of testing behavior in our test suite.
Specifically using this to implement a "StoppableTestConsumer" which can be interrupted during the `.getone()` call from the outside.
This is required to test the graceful shutdown behaviour we've implemented.

Next to that it allows overriding when the `queue.task_done()` is called, to make `TopicManager.join()` wait for all events to be fully processed before continuing to stop the stream engine. This prevents us from requiring `sleep` calls in our tests