### PR TITLE
fix(send): _NoDefault serializer sentinel introduced in order to make…

### DIFF
--- a/kstreams/engine.py
+++ b/kstreams/engine.py
@@ -15,7 +15,7 @@ from .middleware import Middleware
 from .middleware.udf_middleware import UdfHandler
 from .prometheus.monitor import PrometheusMonitor
 from .rebalance_listener import MetricsRebalanceListener, RebalanceListener
-from .serializers import Deserializer, Serializer
+from .serializers import NO_DEFAULT, Deserializer, Serializer
 from .streams import Stream, StreamFunc
 from .streams import stream as stream_func
 from .types import Deprecated, EngineHooks, Headers, NextMiddlewareCall
@@ -96,7 +96,7 @@ class StreamEngine:
         partition: typing.Optional[int] = None,
         timestamp_ms: typing.Optional[int] = None,
         headers: typing.Optional[Headers] = None,
-        serializer: typing.Optional[Serializer] = None,
+        serializer: typing.Optional[Serializer] = NO_DEFAULT,
         serializer_kwargs: typing.Optional[typing.Dict] = None,
     ):
         """
@@ -114,7 +114,8 @@ class StreamEngine:
         if self._producer is None:
             raise EngineNotStartedException()
 
-        serializer = serializer or self.serializer
+        if serializer is NO_DEFAULT:
+            serializer = self.serializer
 
         # serialize only when value and serializer are present
         if value is not None and serializer is not None:

--- a/kstreams/serializers.py
+++ b/kstreams/serializers.py
@@ -4,27 +4,22 @@ from .types import ConsumerRecord, Headers
 
 
 class Deserializer(Protocol):
-    """Protocol used by the Stream to deserialize.
+    """Deserializers must implement the Deserializer Protocol
 
-    A Protocol is similar to other languages features like an interface or a trait.
+    !!! Example
+        ```python
+        import json
+        from kstreams import ConsumerRecord
 
-    End users should provide their own class implementing this protocol.
+        class JsonDeserializer:
 
-    For example a `JsonDeserializer`
-
-    ```python
-    import json
-    from kstreams import ConsumerRecord
-
-    class JsonDeserializer:
-
-        async def deserialize(
-            self, consumer_record: ConsumerRecord, **kwargs
-        ) -> ConsumerRecord:
-            data = json.loads(consumer_record.value.decode())
-            consumer_record.value = data
-            return consumer_record
-    ```
+            async def deserialize(
+                self, consumer_record: ConsumerRecord, **kwargs
+            ) -> ConsumerRecord:
+                data = json.loads(consumer_record.value.decode())
+                consumer_record.value = data
+                return consumer_record
+        ```
     """
 
     async def deserialize(
@@ -75,4 +70,41 @@ class Serializer(Protocol):
         """
         Implement this method to deserialize the data received from the topic.
         """
-        ...
+        ...  # pragma: no cover
+
+
+class _NoDefault:
+    """
+    This class is used as sentinel to indicate that no default serializer
+    value is provided when calling StreamEngine.send(...).
+
+    The sentinel helps to make a distintion between `None` and `_NoDefault` to solve
+    the case when there is a global serializer and `send(serializer=None)` is called
+    to indicate that `binary` must be send rather a serialized payload.
+
+    If we do not have this sentinel, then we can't distinguish when the global
+    serializer should be used or not.
+
+    Example:
+        StreamEngine(...).send("topic", value) # use global serializer if set
+        StreamEngine(...).send("topic", value, serializer=None) # send binary
+        StreamEngine(...).send(
+            "topic", value, serializer=CustomSerializer()) # use custom serializer
+
+        * If a global serializer is not set, then binary is always send.
+
+    """
+
+    async def serialize(
+        self,
+        payload: Any,
+        headers: Optional[Headers] = None,
+        serializer_kwargs: Optional[Dict] = None,
+    ) -> bytes:
+        """
+        Implement this method to deserialize the data received from the topic.
+        """
+        return payload  # pragma: no cover
+
+
+NO_DEFAULT = _NoDefault()

--- a/kstreams/test_utils/test_utils.py
+++ b/kstreams/test_utils/test_utils.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Type
 from kstreams import Consumer, Producer
 from kstreams.engine import StreamEngine
 from kstreams.prometheus.monitor import PrometheusMonitor
-from kstreams.serializers import Serializer
+from kstreams.serializers import NO_DEFAULT, Serializer
 from kstreams.streams import Stream
 from kstreams.types import ConsumerRecord, Headers
 
@@ -116,7 +116,7 @@ class TestStreamClient:
         partition: int = 0,
         timestamp_ms: Optional[int] = None,
         headers: Optional[Headers] = None,
-        serializer: Optional[Serializer] = None,
+        serializer: Optional[Serializer] = NO_DEFAULT,
         serializer_kwargs: Optional[Dict] = None,
     ) -> RecordMetadata:
         return await self.stream_engine.send(

--- a/scripts/cluster/start
+++ b/scripts/cluster/start
@@ -2,6 +2,7 @@
 
 docker-compose up -d
 scripts/cluster/topics/create "local--kstreams"
+scripts/cluster/topics/create "local--kstreams-json"
 scripts/cluster/topics/create "local--hello-world"
 scripts/cluster/topics/create "local--sse"
 scripts/cluster/topics/create "local--avro-user"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -12,7 +12,7 @@ from kstreams.types import Headers
 from kstreams.utils import encode_headers
 
 
-class MySerializer:
+class MyJsonSerializer:
     async def serialize(
         self,
         payload: Any,
@@ -26,7 +26,7 @@ class MySerializer:
         return value.encode()
 
 
-class MyDeserializer:
+class MyJsonDeserializer:
     async def deserialize(self, consumer_record: ConsumerRecord, **kwargs) -> Any:
         if consumer_record.value is not None:
             data = consumer_record.value.decode()
@@ -34,7 +34,10 @@ class MyDeserializer:
 
 
 @pytest.mark.asyncio
-async def test_custom_serialization(stream_engine: StreamEngine, record_metadata):
+async def test_send_global_serializer(stream_engine: StreamEngine, record_metadata):
+    serializer = MyJsonSerializer()
+    stream_engine.serializer = serializer
+
     async def async_func():
         return record_metadata
 
@@ -47,25 +50,88 @@ async def test_custom_serialization(stream_engine: StreamEngine, record_metadata
 
     with mock.patch.multiple(Producer, start=mock.DEFAULT, send=send):
         await stream_engine.start()
-
-        serializer = MySerializer()
-        serialized_data = await serializer.serialize(value)
-
         metadata = await stream_engine.send(
             topic,
             value=value,
             headers=headers,
-            serializer=serializer,
         )
 
         assert metadata
         send.assert_awaited_once_with(
             topic,
-            value=serialized_data,
+            value='{"message": "test"}'.encode(),
             key=None,
             partition=None,
             timestamp_ms=None,
             headers=encode_headers(headers),
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_custom_serialization(stream_engine: StreamEngine, record_metadata):
+    assert stream_engine.serializer is None
+
+    async def async_func():
+        return record_metadata
+
+    send = mock.AsyncMock(return_value=async_func())
+    topic = "my-topic"
+    value = {"message": "test"}
+    headers = {
+        "content-type": consts.APPLICATION_JSON,
+    }
+
+    with mock.patch.multiple(Producer, start=mock.DEFAULT, send=send):
+        await stream_engine.start()
+        metadata = await stream_engine.send(
+            topic,
+            value=value,
+            headers=headers,
+            serializer=MyJsonSerializer(),
+        )
+
+        assert metadata
+        send.assert_awaited_once_with(
+            topic,
+            value='{"message": "test"}'.encode(),
+            key=None,
+            partition=None,
+            timestamp_ms=None,
+            headers=encode_headers(headers),
+        )
+
+
+@pytest.mark.asyncio
+async def test_not_serialize_value(stream_engine: StreamEngine, record_metadata):
+    # even if a serializer is set, we can send the value as is
+    stream_engine.serializer = MyJsonSerializer()
+
+    async def async_func():
+        return record_metadata
+
+    send = mock.AsyncMock(return_value=async_func())
+    topic = "my-topic"
+    value = {"message": "test"}
+
+    with mock.patch.multiple(Producer, start=mock.DEFAULT, send=send):
+        await stream_engine.start()
+        metadata = await stream_engine.send(
+            topic,
+            value=value,
+            serializer=None,
+        )
+
+        assert metadata
+
+        # The value is not serialized, it is send as is
+        # which is will aiokafka to crash because it expects bytes not dict
+        send.assert_awaited_once_with(
+            topic,
+            value={"message": "test"},
+            key=None,
+            partition=None,
+            timestamp_ms=None,
+            headers=None,
         )
 
 
@@ -80,15 +146,18 @@ async def test_custom_serialization(stream_engine: StreamEngine, record_metadata
         (None, {"event-type": "delete-hello-world"}),
     ),
 )
-async def test_custom_deserialization(
+async def test_consume_global_deserialization(
     stream_engine: StreamEngine, value: Optional[Dict], headers: Dict
 ):
+    """
+    Even though deserialzers are deprecated, we still support them.
+    """
     topic = "local--hello-kpn"
+    stream_engine.deserializer = MyJsonDeserializer()
     client = TestStreamClient(stream_engine)
-
     save_to_db = mock.Mock()
 
-    @stream_engine.stream(topic, deserializer=MyDeserializer())
+    @stream_engine.stream(topic)
     async def hello_stream(stream: Stream):
         async for event in stream:
             save_to_db(event)
@@ -100,7 +169,47 @@ async def test_custom_deserialization(
             value=value,
             headers=headers,
             key="1",
-            serializer=MySerializer(),
+            serializer=MyJsonSerializer(),
+        )
+
+    # The payload as been encoded with json,
+    # we expect that the mock has been called with the original value (decoded)
+    save_to_db.assert_called_once_with(value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value, headers",
+    (
+        (
+            {"message": "test"},
+            {"content-type": consts.APPLICATION_JSON, "event-type": "hello-world"},
+        ),
+        (None, {"event-type": "delete-hello-world"}),
+    ),
+)
+async def test_consume_custom_deserialization(
+    stream_engine: StreamEngine, value: Optional[Dict], headers: Dict
+):
+    assert stream_engine.deserializer is None
+    topic = "local--hello-kpn"
+    client = TestStreamClient(stream_engine)
+
+    save_to_db = mock.Mock()
+
+    @stream_engine.stream(topic, deserializer=MyJsonDeserializer())
+    async def hello_stream(stream: Stream):
+        async for event in stream:
+            save_to_db(event)
+
+    async with client:
+        # encode payload with serializer
+        await client.send(
+            topic,
+            value=value,
+            headers=headers,
+            key="1",
+            serializer=MyJsonSerializer(),
         )
 
     # The payload as been encoded with json,


### PR DESCRIPTION
… possible to send raw data even when a global serializer has been set

This PR address the case when the end user wants to send raw data when a global serializer has been set.

Use cases:

 - Multiple topics that expect serialized data, except one: In this case it makes sense to configure a global serializer (StreamEngine) and then produce raw when is needed send(serialzer=None)
- DLQ: to produce raw data (bytes) after a deserialization has failed
