### PR TITLE
fix: RuntimeError await wasn't used with future when the stop engine …

### DIFF
--- a/kstreams/engine.py
+++ b/kstreams/engine.py
@@ -19,7 +19,7 @@ from .serializers import NO_DEFAULT, Deserializer, Serializer
 from .streams import Stream, StreamFunc
 from .streams import stream as stream_func
 from .types import Deprecated, EngineHooks, Headers, NextMiddlewareCall
-from .utils import encode_headers, execute_hooks
+from .utils import encode_headers, execute_hooks, stop_task
 
 logger = logging.getLogger(__name__)
 
@@ -351,13 +351,7 @@ class StreamEngine:
 
     async def stop_stream(self, *, stream: Stream, task: asyncio.Task) -> None:
         await stream.stop()
-
-        if not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                logger.debug(f"Cancelling {task} now")
+        await stop_task(task=task)
 
     async def clean_streams(self):
         await self.stop_streams()

--- a/kstreams/middleware/udf_middleware.py
+++ b/kstreams/middleware/udf_middleware.py
@@ -1,14 +1,13 @@
 import inspect
-import sys
 import typing
 
-from kstreams import types
+from kstreams import types, utils
 from kstreams.streams import Stream
 from kstreams.streams_utils import UDFType, setup_type
 
 from .middleware import BaseMiddleware
 
-if sys.version_info < (3, 10):
+if utils.PY_VERSION < (3, 10):
 
     async def anext(async_gen: typing.AsyncGenerator):
         return await async_gen.__anext__()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 from pytest_httpserver import HTTPServer
 
 from kstreams import clients, create_engine
-from kstreams.utils import create_ssl_context_from_mem
+from kstreams.utils import PY_VERSION, create_ssl_context_from_mem
 
 
 class RecordMetadata(NamedTuple):
@@ -109,7 +109,9 @@ async def stream_engine():
         producer_class=clients.Producer,
     )
     yield stream_engine
-    # await stream_engine.clean_streams()
+
+    if PY_VERSION >= (3, 11):
+        await stream_engine.stop()
 
 
 SSLData = namedtuple("SSLData", ["cabundle", "cert", "key"])


### PR DESCRIPTION
…on a failing test